### PR TITLE
Added functionality to build models with two compositions (baseline and follow-up)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,4 @@ LazyData: true
 Imports: compositions,
     ggplot2
 Suggests: testthat
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3

--- a/R/check_input_args.R
+++ b/R/check_input_args.R
@@ -6,6 +6,7 @@
 #' @param dataf A \code{data.frame} containing data
 #' @param y Name (as string/character vector of length 1) of outcome variable in \code{dataf}
 #' @param comps Character vector of names of compositions in \code{dataf}. See details for more information.
+#' @param comps_fup Character vector of names of compositions at follow up in \code{dataf}. See details for more information.
 #' @param covars Character vector of covariates names  (non-comp variables) in \code{dataf} or NULL for none (default).
 #' @param deltas A vector of time-component changes (as proportions of compositions , i.e., values between -1 and 1). Optional. 
 #' @export
@@ -22,10 +23,7 @@
 # 
 # 
 
-
-
-
-check_input_args <- function(dataf, y, comps, covars, deltas) {
+check_input_args <- function(dataf, y, comps, comps_fup, covars, deltas) {
   
   
   if (!is.data.frame(dataf)) {
@@ -44,6 +42,14 @@ check_input_args <- function(dataf, y, comps, covars, deltas) {
     stop("Please supply a character string of the compositional component column names in dataf.")
   } else if (length(comps) < 2) {
     stop("At least two compositional components are required to create an ilr linear regression.")
+  }
+  
+  if (!is_null_or_na(comps_fup)) {
+    if (!is.character(comps_fup)) {
+      stop("Please supply a character string of the compositional component column names in dataf.")
+    } else if (length(comps_fup) < 2) {
+      stop("At least two compositional components are required to create an ilr linear regression.")
+    }
   }
   
   if (!is_null_or_na(covars) & !is.character(covars)) {

--- a/R/plot_delta_comp.R
+++ b/R/plot_delta_comp.R
@@ -8,9 +8,12 @@ globalVariables(c(
 #'
 #' @author Ty Stanford <tystan@gmail.com>
 #' @description Provided the data (containing outcome, composiitional compoents and covariates), fit a ilr multiple linear regression model and provide predictions from reallocating compositional values pairwise amunsnst the components model.
+#'
 #' @param dc_obj A \code{deltacomp_obj} object returned from the function \code{predict_delta_comps}
 #' @param comp_total A numeric scalar that is the original units of the composition to make the x-axis the original scale instead of in the range \code{[min(delta), max(delta)]} in (-1, 1).
+#' @param graph.sys Graphing system within R. This defaults to "ggplot2" but can be one out of c("base","ggplot2").
 #' @param units_lab Character string of the units of the compositions relating to \code{comp_total} to add to the x-axis label
+#'
 #' @export
 #' @examples 
 #' data(fairclough)
@@ -52,7 +55,8 @@ globalVariables(c(
 
 
 
-plot_delta_comp <- function(dc_obj, comp_total = NULL, units_lab = NULL) {
+plot_delta_comp <- function(dc_obj, comp_total = NULL, units_lab = NULL, 
+                            graph.sys = c("base", "ggplot2")[2]) {
 
   if (!is_deltacomp_obj(dc_obj)) {
     stop("Input needs to be a deltacomp object. i.e., data.frame returned by predict_delta_comps().")
@@ -90,27 +94,49 @@ plot_delta_comp <- function(dc_obj, comp_total = NULL, units_lab = NULL) {
     levels(dc_obj$`comp-`) <- paste0(comps, "-Delta")
   }
   
-  ggp <-
-    ggplot(dc_obj) +
-    geom_vline(xintercept = 0, col = "grey60") +
-    geom_hline(yintercept = 0, col = "grey60") +
-    geom_line(aes(x = delta, y = delta_pred, col = `comp+`)) +
-    geom_point(aes(x = delta, y = delta_pred, col = `comp+`), size = 1) +
-    geom_ribbon(aes(x = delta, ymin = ci_lo, ymax = ci_up, fill = `comp+`), alpha = 0.3) + 
-    theme_bw() +
-    labs(
-      x = paste0("Change/delta in composition", x_lab_add),
-      y = paste0("Predicted change in outcome (", outc, ") with ", ci_lev, "% CI")
-    ) +
-    theme(legend.position = "none")
-  
-
-  if (comparisons == "one-v-one") {
-    ggp <- ggp +
-      facet_grid(`comp-` ~ `comp+`, labeller = label_parsed)
-  } else {
-    ggp <- ggp +
-      facet_wrap(~ `comp+`, labeller = label_parsed)
+  if (graph.sys == "ggplot2") {
+    ggp <-
+      ggplot(dc_obj) +
+      geom_vline(xintercept = 0, col = "grey60") +
+      geom_hline(yintercept = 0, col = "grey60") +
+      geom_line(aes(x = delta, y = delta_pred, col = `comp+`)) +
+      geom_point(aes(x = delta, y = delta_pred, col = `comp+`), size = 1) +
+      geom_ribbon(aes(x = delta, ymin = ci_lo, ymax = ci_up, fill = `comp+`), alpha = 0.3) + 
+      theme_bw() +
+      labs(
+        x = paste0("Change/delta in composition", x_lab_add),
+        y = paste0("Predicted change in outcome (", outc, ") with ", ci_lev, "% CI")
+      ) +
+      theme(legend.position = "none")
+    
+    
+    if (comparisons == "one-v-one") {
+      ggp <- ggp +
+        facet_grid(`comp-` ~ `comp+`, labeller = label_parsed)
+    } else {
+      ggp <- ggp +
+        facet_wrap(~ `comp+`, labeller = label_parsed)
+    } 
+  } else if (graph.sys == "base") {
+    # to do....
+    # PLOT
+    par(las = 1, mfrow = c(2,2))
+    for (part in unique(dc_obj$`comp+`)) {
+      thisPlot = which(dc_obj$`comp+` == part)
+      plot(x = dc_obj$delta[thisPlot], y = dc_obj$delta_pred[thisPlot], 
+           type = "o", pch = 19,
+           main = bquote(.(gsub("+Delta", "", part, fixed = T)) + Delta),
+           font.main=1,
+           col = colors[4], lwd = 3, 
+           xlim = range(dc_obj$delta),
+           ylim = range(c(dc_obj$ci_lo, dc_obj$ci_up)),
+           ylab = paste0("Predicted change in outcome (", outc, ") with ", ci_lev, "% CI"), 
+           xlab = paste0("Change/delta in composition", x_lab_add))
+      polygon(x = c(dc_obj$delta[thisPlot], rev(dc_obj$delta[thisPlot])), 
+              y = c(dc_obj$ci_lo[thisPlot], rev(dc_obj$ci_up[thisPlot])),
+              border = NA, col = myfunctions::add_alpha("red", alpha), fillOddEven = FALSE)
+      abline(h = 0)
+    }
   }
   
   return(ggp)

--- a/R/plot_delta_comp.R
+++ b/R/plot_delta_comp.R
@@ -8,12 +8,9 @@ globalVariables(c(
 #'
 #' @author Ty Stanford <tystan@gmail.com>
 #' @description Provided the data (containing outcome, composiitional compoents and covariates), fit a ilr multiple linear regression model and provide predictions from reallocating compositional values pairwise amunsnst the components model.
-#'
 #' @param dc_obj A \code{deltacomp_obj} object returned from the function \code{predict_delta_comps}
 #' @param comp_total A numeric scalar that is the original units of the composition to make the x-axis the original scale instead of in the range \code{[min(delta), max(delta)]} in (-1, 1).
-#' @param graph.sys Graphing system within R. This defaults to "ggplot2" but can be one out of c("base","ggplot2").
 #' @param units_lab Character string of the units of the compositions relating to \code{comp_total} to add to the x-axis label
-#'
 #' @export
 #' @examples 
 #' data(fairclough)
@@ -55,9 +52,8 @@ globalVariables(c(
 
 
 
-plot_delta_comp <- function(dc_obj, comp_total = NULL, units_lab = NULL, 
-                            graph.sys = c("base", "ggplot2")[2]) {
-
+plot_delta_comp <- function(dc_obj, comp_total = NULL, units_lab = NULL) {
+  
   if (!is_deltacomp_obj(dc_obj)) {
     stop("Input needs to be a deltacomp object. i.e., data.frame returned by predict_delta_comps().")
   }
@@ -94,56 +90,30 @@ plot_delta_comp <- function(dc_obj, comp_total = NULL, units_lab = NULL,
     levels(dc_obj$`comp-`) <- paste0(comps, "-Delta")
   }
   
-  if (graph.sys == "ggplot2") {
-    ggp <-
-      ggplot(dc_obj) +
-      geom_vline(xintercept = 0, col = "grey60") +
-      geom_hline(yintercept = 0, col = "grey60") +
-      geom_line(aes(x = delta, y = delta_pred, col = `comp+`)) +
-      geom_point(aes(x = delta, y = delta_pred, col = `comp+`), size = 1) +
-      geom_ribbon(aes(x = delta, ymin = ci_lo, ymax = ci_up, fill = `comp+`), alpha = 0.3) + 
-      theme_bw() +
-      labs(
-        x = paste0("Change/delta in composition", x_lab_add),
-        y = paste0("Predicted change in outcome (", outc, ") with ", ci_lev, "% CI")
-      ) +
-      theme(legend.position = "none")
-    
-    
-    if (comparisons == "one-v-one") {
-      ggp <- ggp +
-        facet_grid(`comp-` ~ `comp+`, labeller = label_parsed)
-    } else {
-      ggp <- ggp +
-        facet_wrap(~ `comp+`, labeller = label_parsed)
-    } 
-  } else if (graph.sys == "base") {
-    # to do....
-    # PLOT
-    par(las = 1, mfrow = c(2,2))
-    for (part in unique(dc_obj$`comp+`)) {
-      thisPlot = which(dc_obj$`comp+` == part)
-      plot(x = dc_obj$delta[thisPlot], y = dc_obj$delta_pred[thisPlot], 
-           type = "o", pch = 19,
-           main = bquote(.(gsub("+Delta", "", part, fixed = T)) + Delta),
-           font.main=1,
-           col = colors[4], lwd = 3, 
-           xlim = range(dc_obj$delta),
-           ylim = range(c(dc_obj$ci_lo, dc_obj$ci_up)),
-           ylab = paste0("Predicted change in outcome (", outc, ") with ", ci_lev, "% CI"), 
-           xlab = paste0("Change/delta in composition", x_lab_add))
-      polygon(x = c(dc_obj$delta[thisPlot], rev(dc_obj$delta[thisPlot])), 
-              y = c(dc_obj$ci_lo[thisPlot], rev(dc_obj$ci_up[thisPlot])),
-              border = NA, col = myfunctions::add_alpha("red", alpha), fillOddEven = FALSE)
-      abline(h = 0)
-    }
+  ggp <-
+    ggplot(dc_obj) +
+    geom_vline(xintercept = 0, col = "grey60") +
+    geom_hline(yintercept = 0, col = "grey60") +
+    geom_line(aes(x = delta, y = delta_pred, col = `comp+`)) +
+    geom_point(aes(x = delta, y = delta_pred, col = `comp+`), size = 1) +
+    geom_ribbon(aes(x = delta, ymin = ci_lo, ymax = ci_up, fill = `comp+`), alpha = 0.3) + 
+    theme_bw() +
+    labs(
+      x = paste0("Change/delta in composition", x_lab_add),
+      y = paste0("Predicted change in outcome (", outc, ") with ", ci_lev, "% CI")
+    ) +
+    theme(legend.position = "none")
+  
+  
+  if (comparisons == "one-v-one") {
+    ggp <- ggp +
+      facet_grid(`comp-` ~ `comp+`, labeller = label_parsed)
+  } else {
+    ggp <- ggp +
+      facet_wrap(~ `comp+`, labeller = label_parsed)
   }
   
   return(ggp)
-
-
+  
+  
 }
-
-
-
-

--- a/man/check_input_args.Rd
+++ b/man/check_input_args.Rd
@@ -4,7 +4,7 @@
 \alias{check_input_args}
 \title{Sanity checks for arguments passed to predict_delta_comps()}
 \usage{
-check_input_args(dataf, y, comps, covars, deltas)
+check_input_args(dataf, y, comps, comps_fup, covars, deltas)
 }
 \arguments{
 \item{dataf}{A \code{data.frame} containing data}
@@ -12,6 +12,8 @@ check_input_args(dataf, y, comps, covars, deltas)
 \item{y}{Name (as string/character vector of length 1) of outcome variable in \code{dataf}}
 
 \item{comps}{Character vector of names of compositions in \code{dataf}. See details for more information.}
+
+\item{comps_fup}{Character vector of names of compositions at follow up in \code{dataf}. See details for more information.}
 
 \item{covars}{Character vector of covariates names  (non-comp variables) in \code{dataf} or NULL for none (default).}
 

--- a/man/plot_delta_comp.Rd
+++ b/man/plot_delta_comp.Rd
@@ -4,12 +4,7 @@
 \alias{plot_delta_comp}
 \title{Get predictions from compositional ilr multiple linear regression model}
 \usage{
-plot_delta_comp(
-  dc_obj,
-  comp_total = NULL,
-  units_lab = NULL,
-  graph.sys = c("base", "ggplot2")[2]
-)
+plot_delta_comp(dc_obj, comp_total = NULL, units_lab = NULL)
 }
 \arguments{
 \item{dc_obj}{A \code{deltacomp_obj} object returned from the function \code{predict_delta_comps}}
@@ -17,8 +12,6 @@ plot_delta_comp(
 \item{comp_total}{A numeric scalar that is the original units of the composition to make the x-axis the original scale instead of in the range \code{[min(delta), max(delta)]} in (-1, 1).}
 
 \item{units_lab}{Character string of the units of the compositions relating to \code{comp_total} to add to the x-axis label}
-
-\item{graph.sys}{Graphing system within R. This defaults to "ggplot2" but can be one out of c("base","ggplot2").}
 }
 \description{
 Provided the data (containing outcome, composiitional compoents and covariates), fit a ilr multiple linear regression model and provide predictions from reallocating compositional values pairwise amunsnst the components model.

--- a/man/plot_delta_comp.Rd
+++ b/man/plot_delta_comp.Rd
@@ -4,7 +4,12 @@
 \alias{plot_delta_comp}
 \title{Get predictions from compositional ilr multiple linear regression model}
 \usage{
-plot_delta_comp(dc_obj, comp_total = NULL, units_lab = NULL)
+plot_delta_comp(
+  dc_obj,
+  comp_total = NULL,
+  units_lab = NULL,
+  graph.sys = c("base", "ggplot2")[2]
+)
 }
 \arguments{
 \item{dc_obj}{A \code{deltacomp_obj} object returned from the function \code{predict_delta_comps}}
@@ -12,6 +17,8 @@ plot_delta_comp(dc_obj, comp_total = NULL, units_lab = NULL)
 \item{comp_total}{A numeric scalar that is the original units of the composition to make the x-axis the original scale instead of in the range \code{[min(delta), max(delta)]} in (-1, 1).}
 
 \item{units_lab}{Character string of the units of the compositions relating to \code{comp_total} to add to the x-axis label}
+
+\item{graph.sys}{Graphing system within R. This defaults to "ggplot2" but can be one out of c("base","ggplot2").}
 }
 \description{
 Provided the data (containing outcome, composiitional compoents and covariates), fit a ilr multiple linear regression model and provide predictions from reallocating compositional values pairwise amunsnst the components model.

--- a/man/predict_delta_comps.Rd
+++ b/man/predict_delta_comps.Rd
@@ -8,9 +8,11 @@ predict_delta_comps(
   dataf,
   y,
   comps,
+  comps_fup = NULL,
   covars = NULL,
-  deltas = c(0, 10, 20)/(24 * 60),
+  analysis_type = c("cross-sectional", "long_prospective", "long_change")[1],
   comparisons = c("prop-realloc", "one-v-one")[1],
+  deltas = c(0, 10, 20)/(24 * 60),
   alpha = 0.05
 )
 }
@@ -23,11 +25,11 @@ predict_delta_comps(
 
 \item{covars}{Optional. Character vector of covariates names  (non-comp variables) in \code{dataf}. Defaults to NULL.}
 
+\item{comparisons}{Currently two choices:  \code{"one-v-one"} or  \code{"prop-realloc"} (default). Please see details for explanation of these methods.}
+
 \item{deltas}{A vector of time-component changes (as proportions of compositions , i.e., values between -1 and 1). Optional. 
 Changes in compositions to be computed pairwise. Defaults to 0, 10 and 20 minutes as a proportion of the 1440 minutes 
 in a day (i.e., approximately \code{0.000}, \code{0.007} and \code{0.014}).}
-
-\item{comparisons}{Currently two choices:  \code{"one-v-one"} or  \code{"prop-realloc"} (default). Please see details for explanation of these methods.}
 
 \item{alpha}{Optional. Level of significance. Defaults to 0.05.}
 }

--- a/man/predict_delta_comps.Rd
+++ b/man/predict_delta_comps.Rd
@@ -10,7 +10,7 @@ predict_delta_comps(
   comps,
   comps_fup = NULL,
   covars = NULL,
-  analysis_type = c("cross-sectional", "long_prospective", "long_change")[1],
+  analysis_type = c("cross-sectional", "longitudinal")[1],
   comparisons = c("prop-realloc", "one-v-one")[1],
   deltas = c(0, 10, 20)/(24 * 60),
   alpha = 0.05
@@ -21,9 +21,13 @@ predict_delta_comps(
 
 \item{y}{Name (as string/character vector of length 1) of outcome variable in \code{dataf}}
 
-\item{comps}{Character vector of names of compositions in \code{dataf}. See details for more information.}
+\item{comps}{Optional character vector of names of compositions in \code{dataf}. See details for more information.}
+
+\item{comps_fup}{Character vector of names of compositions at follow-up in \code{dataf}. See details for more information.}
 
 \item{covars}{Optional. Character vector of covariates names  (non-comp variables) in \code{dataf}. Defaults to NULL.}
+
+\item{analysis_type}{Currently two choices:  \code{"cross-sectional"} (default) or  \code{"longitudinal"}. Please see details for explanation of these methods.}
 
 \item{comparisons}{Currently two choices:  \code{"one-v-one"} or  \code{"prop-realloc"} (default). Please see details for explanation of these methods.}
 
@@ -43,6 +47,8 @@ values as the function normalises the compositions row-wise to sum to 1 in part 
 Please see the \code{deltacomp} package \code{README.md} file for examples and explanation of the \code{comparisons = "prop-realloc"} and \code{comparisons = "one-v-one"} options. 
 
 Note from version 0.1.0 to current version, \code{comparisons == "one-v-all"} is depreciated, \code{comparisons == "prop-realloc"} is probably the alternative you are after.
+
+\code{analysis_type == "longitudinal"} expects a second measurement of the composition (\code{comps_fup}). If longitudinal, the ilr coordinates of the follow-up composition will be calculated and used as covariates to adjust the regression model.
 }
 \examples{
 predict_delta_comps(
@@ -64,7 +70,6 @@ predict_delta_comps(
   comparisons = "one-v-one",
   alpha = 0.05
 )
-
 }
 \author{
 Ty Stanford <tystan@gmail.com>

--- a/tests/testthat/test_check_input_args.R
+++ b/tests/testthat/test_check_input_args.R
@@ -57,30 +57,36 @@ test_that("predict_delta_comps() correctly throws errors via check_input_args() 
   )
   
   expect_error(
-    predict_delta_comps(dataf = fairclough, fa_y, "sed", fa_covars, fa_deltas, fa_comparisons, fa_alpha),
+    predict_delta_comps(dataf = fairclough, y = fa_y, comps = "sed", covars = fa_covars, 
+                        deltas = fa_deltas, comparisons = fa_comparisons, alpha = fa_alpha),
     "At least two compositional components"
   )
   
   expect_error(
-    predict_delta_comps(dataf = fairclough, fa_y, fa_comps, 1, fa_deltas, fa_comparisons, fa_alpha),
+    predict_delta_comps(dataf = fairclough, y = fa_y, comps = fa_comps, covars = 1, 
+                        deltas = fa_deltas, comparisons = fa_comparisons, alpha = fa_alpha),
     "Please supply a character string of the covariate"
   )
   expect_error(
-    predict_delta_comps(dataf = fairclough, fa_y, fa_comps, TRUE, fa_deltas, fa_comparisons, fa_alpha),
+    predict_delta_comps(dataf = fairclough, y = fa_y, comps = fa_comps, covars = TRUE, 
+                        deltas = fa_deltas, comparisons = fa_comparisons, alpha = fa_alpha),
     "Please supply a character string of the covariate"
   )
   
   expect_error(
-    predict_delta_comps(dataf = fairclough, fa_y, fa_comps, fa_covars, -1.1, fa_comparisons, fa_alpha),
+    predict_delta_comps(dataf = fairclough, y = fa_y, comps = fa_comps, covars = fa_covars, 
+                        deltas = -1.1, comparisons = fa_comparisons, alpha = fa_alpha),
     "deltas must be specified as positive and negative proportions"
   )
   expect_error(
-    predict_delta_comps(dataf = fairclough, fa_y, fa_comps, fa_covars, +1.1, fa_comparisons, fa_alpha),
+    predict_delta_comps(dataf = fairclough, y = fa_y, comps = fa_comps, covars = fa_covars, 
+                        deltas = +1.1, comparisons = fa_comparisons, alpha = fa_alpha),
     "deltas must be specified as positive and negative proportions"
   )
   
   expect_error(
-    predict_delta_comps(dataf = fairclough[1:6, ], fa_y, fa_comps, fa_covars, fa_deltas, fa_comparisons, fa_alpha),
+    predict_delta_comps(dataf = fairclough[1:6,], y = fa_y, comps = fa_comps, covars = fa_covars, 
+                        deltas = fa_deltas, comparisons = fa_comparisons, alpha = fa_alpha),
     "The number of rows.*"
   )
 

--- a/tests/testthat/test_check_strictly_positive_vals.R
+++ b/tests/testthat/test_check_strictly_positive_vals.R
@@ -38,17 +38,19 @@ test_that("check_strictly_positive_vals() correctly throws errors for bad input"
     "Values less than"
   )
   expect_error(
-    predict_delta_comps(dataf = f2, fa_y, fa_comps, fa_covars, fa_deltas, fa_comparisons, fa_alpha),
+    predict_delta_comps(dataf = f2, y = fa_y, comps = fa_comps, covars = fa_covars, 
+                        deltas = fa_deltas, comparisons = fa_comparisons, alpha = fa_alpha),
     "Values less than"
   )
   
   
   expect_error(
-    check_strictly_positive_vals(dataf = f3, fa_comps),
+    check_strictly_positive_vals(dataf = f3, comps = fa_comps),
     "Values less than"
   )
   expect_error(
-    predict_delta_comps(dataf = f3, fa_y, fa_comps, fa_covars, fa_deltas, fa_comparisons, fa_alpha),
+    predict_delta_comps(dataf = f3, y = fa_y, comps = fa_comps, covars = fa_covars, 
+                        deltas = fa_deltas, comparisons = fa_comparisons, alpha = fa_alpha),
     "Values less than"
   )
   

--- a/tests/testthat/test_rm_na_data_rows.R
+++ b/tests/testthat/test_rm_na_data_rows.R
@@ -36,7 +36,8 @@ test_that("rm_na_data_rows() correctly removes NAs", {
     f1[-c(5, 10, 6, 2), c(fa_y, fa_comps, fa_covars)]
   )
   expect_error(
-    predict_delta_comps(dataf = f1, fa_y, fa_comps, fa_covars, fa_deltas, fa_comparisons, fa_alpha),
+    predict_delta_comps(dataf = f1, y = fa_y, comps = fa_comps, covars = fa_covars, 
+                        deltas = fa_deltas, comparisons = fa_comparisons, alpha = fa_alpha),
     "The number of rows in dataf"
   )
   
@@ -45,7 +46,8 @@ test_that("rm_na_data_rows() correctly removes NAs", {
     f2[0,  c(fa_y, fa_comps, fa_covars)]
   )  
   expect_error(
-    predict_delta_comps(dataf = f2, fa_y, fa_comps, fa_covars, fa_deltas, fa_comparisons, fa_alpha),
+    predict_delta_comps(dataf = f2, y = fa_y, comps = fa_comps, covars = fa_covars, 
+                        deltas = fa_deltas, comparisons = fa_comparisons, alpha = fa_alpha),
     "dataf supplied must"
   )
   


### PR DESCRIPTION
Hi @tystan, first congrats for a nice and useful package. I work in several projects in which we measured the movement behaviors twice (baseline and follow-up). We are often interested in running longitudinal analyses to investigate the prospective association of baseline behaviors with outcomes at follow-up, and we use the behaviors measured at follow-up to adjust the models. I added this functionality to the `predict_delta_comps` function, so that if `comps_fup` is provided and `analysis_type == "longitudinal"`, then it would calculate the ilr coordinates for the follow-up composition and use them to adjust the linear regression model. 

I'm doing this pull request just in case you are interested in adding this to your package, the original functionality is not compromised.